### PR TITLE
Add task metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TWINE_API_KEY }}
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: './dist/*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,17 +34,17 @@ classifiers = [
 ]
 
 dependencies = [
-    "fractal-tasks-core==1.2.1",
+    "fractal-tasks-core==1.3.3",
     "pydantic",
     "zarr",
-    "faim-ipa==0.5.0",
+    "faim-ipa==0.9.2",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 # "extras" (e.g. for `pip install .[test]`)
 [project.optional-dependencies]
 # add dependencies used for testing here
-test = ["pytest", "pytest-cov", "jsonschema"]
+test = ["pytest", "pytest-cov", "jsonschema", "devtools"]
 # add anything else you like to have in your dev environment here
 dev = [
     "black",

--- a/src/fractal_faim_ipa/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_faim_ipa/__FRACTAL_MANIFEST__.json
@@ -3,21 +3,27 @@
   "task_list": [
     {
       "name": "FAIM IPA OME-Zarr Converter",
+      "category": "Conversion",
+      "modality": "HCS",
+      "tags": [
+        "Molecular Devices",
+        "Image Xpress",
+        "MD"
+      ],
       "executable_non_parallel": "convert_ome_zarr.py",
       "meta_non_parallel": {
         "cpus_per_task": 8,
         "mem": 32000
       },
       "args_schema_non_parallel": {
-        "title": "ConvertOmeZarr",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. Not used by the converter task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -31,7 +37,6 @@
             "description": "Path to the folder containing the images to be converted."
           },
           "mode": {
-            "title": "Mode",
             "enum": [
               "MD Stack Acquisition",
               "MD Single Plane Acquisition",
@@ -41,68 +46,69 @@
               "MetaXpress MD Single Plane Acquisition as 3D",
               "MetaXpress MD Mixed Acquisition"
             ],
+            "title": "Mode",
             "type": "string",
             "description": "Choose conversion mode. MetaXpress modes are used when data is exported via MetaXpress. Choose whether you have 3D data (StackAcquisition), 2D data (Single Plane Acquisition) or mixed."
           },
           "zarr_name": {
-            "title": "Zarr Name",
             "default": "Plate",
+            "title": "Zarr Name",
             "type": "string",
             "description": "Name of the zarr plate file that will be created"
           },
           "tile_alignment": {
-            "title": "Tile Alignment",
             "default": "GridAlignment",
             "enum": [
               "StageAlignment",
               "GridAlignment"
             ],
+            "title": "Tile Alignment",
             "type": "string",
             "description": "Choose whether tiles are placed into the OME-Zarr as a grid or whether they are placed based on the position of field of views in the metadata (using fusion for shared areas)."
           },
           "layout": {
-            "title": "Layout",
             "default": 96,
             "enum": [
               96,
               384
             ],
+            "title": "Layout",
             "type": "integer",
             "description": "Plate layout for the Zarr file. Valid options are 96 and 384"
           },
           "query": {
-            "title": "Query",
             "default": "",
+            "title": "Query",
             "type": "string",
             "description": "Pandas query to filter the file list."
           },
           "order_name": {
-            "title": "Order Name",
             "default": "example-order",
+            "title": "Order Name",
             "type": "string",
             "description": "Name of the order"
           },
           "barcode": {
-            "title": "Barcode",
             "default": "example-barcode",
+            "title": "Barcode",
             "type": "string",
             "description": "Barcode of the plate"
           },
           "overwrite": {
-            "title": "Overwrite",
             "default": false,
+            "title": "Overwrite",
             "type": "boolean",
             "description": "Whether to overwrite the zarr file if it already exists"
           },
           "binning": {
-            "title": "Binning",
             "default": 1,
+            "title": "Binning",
             "type": "integer",
             "description": "Binning factor to downsample the original image. If set to 2, an image that is 2x2 downsampled in xy will be produced."
           },
           "parallelize": {
-            "title": "Parallelize",
             "default": true,
+            "title": "Parallelize",
             "type": "boolean",
             "description": "The automatic distribute.Client option often fails to finish when running the task locally. Set parallelize to false to avoid that."
           }
@@ -113,11 +119,12 @@
           "image_dir",
           "mode"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "ConvertOmeZarr"
       },
       "docs_info": "## convert_ome_zarr\nCreate OME-Zarr plate from MD Image Xpress files.\n\nThis is a non-parallel task => it parses the metadata, creates the plates\nand then converts all the wells in the same process\n"
     }
   ],
   "has_args_schemas": true,
-  "args_schema_version": "pydantic_v1"
+  "args_schema_version": "pydantic_v2"
 }

--- a/src/fractal_faim_ipa/dev/task_list.py
+++ b/src/fractal_faim_ipa/dev/task_list.py
@@ -7,5 +7,8 @@ TASK_LIST = [
         name="FAIM IPA OME-Zarr Converter",
         executable="convert_ome_zarr.py",
         meta={"cpus_per_task": 8, "mem": 32000},
+        category="Conversion",
+        modality="HCS",
+        tags=["Molecular Devices", "Image Xpress", "MD"],
     ),
 ]


### PR DESCRIPTION
We're adding metadata to the tasks to be able to build better task interfaces. I've created this PR to show how this metadata is structured. The core fields for each task are:

1. Category: Conversion, Segmentation, Registration, Measurement, Image Processing
2. Modality: HCS, lightsheet, EM
3. Tags: Arbitrary strings that are searchable and provide info about the task

Category & Modality work by convention, but you can add new entries when useful.

Additionally, there is now an "authors" field for the whole package.

In order for the future public Fractal page to list your tasks (see https://github.com/fractal-analytics-platform/fractal-analytics-platform.github.io/issues/6), the package needs to either be on PyPI or have github releases with whl files. As part of this PR, I'm adding a Github CI that would run tests and create releases with whl files upon tags. 

----

Other additions:
1. Update faim-ipa version to 0.9.2 => make parsing robust to whether a TimePoint folder exists or not
2. Update fractal-tasks-core version to 1.3.3