### PR TITLE
Add multiplexing support to MD converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "fractal-tasks-core==1.5.0",
     "pydantic",
     "zarr",
-    "faim-ipa==0.11.0",
+    "faim-ipa==0.13.0",
     "fractal-task-tools==0.0.12",
 ]
 

--- a/src/fractal_faim_ipa/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_faim_ipa/__FRACTAL_MANIFEST__.json
@@ -18,6 +18,35 @@
         "mem": 32000
       },
       "args_schema_non_parallel": {
+        "$defs": {
+          "AcquisitionInputModel": {
+            "description": "Acquisition metadata.",
+            "properties": {
+              "path": {
+                "title": "Path",
+                "type": "string",
+                "description": "Path to the acquisition directory. For the MD, this is the folder that contains a date folder and an ID folder. If the images are in /path/to/project_name/2025-05-12/1234, then the path should be /path/to/project_name."
+              },
+              "plate_name": {
+                "title": "Plate Name",
+                "type": "string",
+                "description": "Optional custom name for the plate. If not provided, the name will be the acquisition directory name."
+              },
+              "acquisition_id": {
+                "default": 0,
+                "minimum": 0,
+                "title": "Acquisition Id",
+                "type": "integer",
+                "description": "Acquisition ID, used to identify the acquisition in case of multiple acquisitions."
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "title": "AcquisitionInputModel",
+            "type": "object"
+          }
+        },
         "additionalProperties": false,
         "properties": {
           "zarr_dir": {
@@ -25,10 +54,13 @@
             "type": "string",
             "description": "path of the directory where the new OME-Zarrs will be created. (standard argument for Fractal tasks, managed by Fractal server)."
           },
-          "image_dir": {
-            "title": "Image Dir",
-            "type": "string",
-            "description": "Path to the folder containing the images to be converted."
+          "acquisitions": {
+            "items": {
+              "$ref": "#/$defs/AcquisitionInputModel"
+            },
+            "title": "Acquisitions",
+            "type": "array",
+            "description": "List of acquisition directories to convert to OME-Zarr. If you are processing multiplexing experiments, name the plate the same for all acquisitions, but give them unique acquisition IDs. If you are processing multiple separate plates, give the plates unique names."
           },
           "mode": {
             "enum": [
@@ -39,12 +71,6 @@
             "title": "Mode",
             "type": "string",
             "description": "Choose conversion mode. Choose whether you have 3D data (StackAcquisition), 2D data (Single Plane Acquisition) or mixed (Mixed Acquisition)."
-          },
-          "zarr_name": {
-            "default": "Plate",
-            "title": "Zarr Name",
-            "type": "string",
-            "description": "Name of the zarr plate file that will be created"
           },
           "tile_alignment": {
             "default": "GridAlignment",
@@ -84,11 +110,11 @@
             "type": "string",
             "description": "Barcode of the plate"
           },
-          "overwrite": {
+          "reset_plates": {
             "default": false,
-            "title": "Overwrite",
+            "title": "Reset Plates",
             "type": "boolean",
-            "description": "Whether to overwrite the zarr file if it already exists"
+            "description": "Whether to remove any potentially pre-existing OME-Zarr plates before conversion."
           },
           "binning": {
             "default": 1,
@@ -105,7 +131,7 @@
         },
         "required": [
           "zarr_dir",
-          "image_dir",
+          "acquisitions",
           "mode"
         ],
         "type": "object",

--- a/src/fractal_faim_ipa/convert_ome_zarr.py
+++ b/src/fractal_faim_ipa/convert_ome_zarr.py
@@ -5,6 +5,7 @@ from os.path import exists, join
 from typing import Any, Literal
 
 import distributed
+import ngio
 from faim_ipa.hcs.acquisition import TileAlignmentOptions
 from faim_ipa.hcs.converter import ConvertToNGFFPlate, NGFFPlate, PlateLayout
 from faim_ipa.stitching import stitching_utils
@@ -40,7 +41,7 @@ class AcquisitionInputModel(BaseModel):
 
 
 @validate_call
-def convert_ome_zarr(
+def convert_ome_zarr(  # noqa: C901
     *,
     zarr_dir: str,
     acquisitions: list[AcquisitionInputModel],
@@ -58,7 +59,7 @@ def convert_ome_zarr(
     num_levels: int = 5,
     order_name: str = "example-order",
     barcode: str = "example-barcode",
-    overwrite: bool = False,
+    reset_plates: bool = False,
     binning: int = 1,
     parallelize: bool = True,
 ) -> dict[str, Any]:
@@ -90,7 +91,8 @@ def convert_ome_zarr(
             levels are useful for large plates to allow easier plate
             visualization, but will also lead to more files being created.
         barcode: Barcode of the plate
-        overwrite: Whether to overwrite the zarr file if it already exists
+        reset_plates: Whether to remove any potentially pre-existing OME-Zarr
+            plates before conversion.
         binning: Binning factor to downsample the original image. If set to 2,
             an image that is 2x2 downsampled in xy will be produced.
         parallelize: The automatic distribute.Client option often fails to
@@ -104,23 +106,33 @@ def convert_ome_zarr(
     layout = PlateLayout(layout)
     tile_alignment = TileAlignmentOptions(tile_alignment)
     zarr_dir = zarr_dir.rstrip("/")
+    image_list_updates = []
 
-    # TODO: Loop over plates for multiplexing or creating multiple plates
-    plate_name = acquisitions[0].plate_name
-    if plate_name is None:
-        plate_name = acquisitions[0].path.rstrip("/").split("/")[-1]
+    is_multiplexed = check_is_multiplexing(acquisitions)
+    if is_multiplexed:
+        logger.info(
+            f"Processing a multiplexing acquisition with plates {acquisitions=}"
+        )
+    else:
+        logger.info(
+            f"Processing a non-multiplexing acquisition with plates {acquisitions=}"
+        )
+
     # TO REVIEW: Overwrite checks are not exposed in faim-hcs API
     # Unclear how faim-hcs handles rerunning the plate creation
     # (the Zarr file gets a newer timestamp at least)
     # This block triggers a reset
-    if overwrite and exists(join(zarr_dir, plate_name + ".zarr")):
-        # Remove zarr if it already exists.
-        shutil.rmtree(join(zarr_dir, plate_name + ".zarr"))
-
-    plate_acquisition = mode.get_plate_acquisition(
-        acquisition_dir=acquisitions[0].path,
-        alignment=tile_alignment,
-    )
+    for acquisition in acquisitions:
+        if exists(join(zarr_dir, acquisition.plate_name + ".zarr")):
+            if reset_plates:
+                # Remove zarr if it already exists.
+                shutil.rmtree(join(zarr_dir, acquisition.plate_name + ".zarr"))
+            else:
+                logger.warning(
+                    f"Zarr file {acquisition.plate_name + '.zarr'} already "
+                    f"exists and wasn't reset due to {reset_plates=}. This "
+                    "may lead to unexpected behavior.",
+                )
 
     # The automatic distribute.Client option often fails to finish when
     # running the task locally. Set parallelize to false to avoid that.
@@ -133,79 +145,159 @@ def convert_ome_zarr(
             processes=False,
         )
 
-    converter = ConvertToNGFFPlate(
-        ngff_plate=NGFFPlate(
-            root_dir=zarr_dir,
-            name=plate_name,
-            layout=int(layout),
-            order_name=order_name,
-            barcode=barcode,
-        ),
-        yx_binning=binning,
-        warp_func=stitching_utils.translate_tiles_2d,
-        fuse_func=stitching_utils.fuse_mean,
-        client=client,
-    )
+    for acquisition in acquisitions:
+        plate_name = acquisition.plate_name
+        if plate_name is None:
+            plate_name = acquisition.path.rstrip("/").split("/")[-1]
 
-    plate = converter.create_zarr_plate(plate_acquisition)
+        plate_acquisition = mode.get_plate_acquisition(
+            acquisition_dir=acquisition.path,
+            alignment=tile_alignment,
+        )
 
-    # TODO: Remove hard-coded well sub group? Or make flexible for multiplexing
-    well_sub_group = "0"
-    well_acquisitions = plate_acquisition.get_well_acquisitions(selection=None)
+        converter = ConvertToNGFFPlate(
+            ngff_plate=NGFFPlate(
+                root_dir=zarr_dir,
+                name=plate_name,
+                layout=int(layout),
+                order_name=order_name,
+                barcode=barcode,
+            ),
+            yx_binning=binning,
+            warp_func=stitching_utils.translate_tiles_2d,
+            fuse_func=stitching_utils.fuse_mean,
+            client=client,
+        )
 
-    full_plate_name = plate_name + ".zarr"
+        plate = converter.create_zarr_plate(plate_acquisition)
 
-    image_list_updates = []
-    # TODO: Add more robust handling for dimensionality detection
-    if mode == ModeEnum.SinglePlaneAcquisition:
-        is_3D = False
-    else:
-        is_3D = True
+        well_sub_group = str(acquisition.acquisition_id)
+        well_acquisitions = plate_acquisition.get_well_acquisitions(selection=None)
 
-    # Run conversion.
-    converter.run(
-        plate=plate,
-        plate_acquisition=plate_acquisition,
-        well_sub_group=well_sub_group,
-        # chunks=(2048, 2048), # check whether that should be exposed
-        max_layer=num_levels - 1,
-    )
+        full_plate_name = plate_name + ".zarr"
 
-    # Write ROI tables to the images
-    roi_tables = create_ROI_tables(plate_acquisition=plate_acquisition)
-    for well_acquisition in well_acquisitions:
-        # Write the tables
-        well_rc = well_acquisition.get_row_col()
-        image_group = plate[well_rc[0]][well_rc[1]][well_sub_group]
-        tables = roi_tables[well_acquisition.name].keys()
-        for table_name in tables:
-            write_table(
-                image_group=image_group,
-                table_name=table_name,
-                table=roi_tables[well_acquisition.name][table_name],
-                overwrite=overwrite,
-                table_type="roi_table",
-                table_attrs=None,
+        # TODO: Add more robust handling for dimensionality detection
+        if mode == ModeEnum.SinglePlaneAcquisition:
+            is_3D = False
+        else:
+            is_3D = True
+
+        # Run conversion.
+        converter.run(
+            plate=plate,
+            plate_acquisition=plate_acquisition,
+            well_sub_group=well_sub_group,
+            # chunks=(2048, 2048), # check whether that should be exposed
+            max_layer=num_levels - 1,
+        )
+
+        # Manually add acquisition metadata to the wells
+        plate_url = f"{zarr_dir}/{full_plate_name}"
+        add_acquisition_metadata_to_wells(
+            plate_url=plate_url,
+            acquisition_id=acquisition.acquisition_id,
+        )
+
+        # Write ROI tables to the images
+        roi_tables = create_ROI_tables(plate_acquisition=plate_acquisition)
+        for well_acquisition in well_acquisitions:
+            # Write the tables
+            well_rc = well_acquisition.get_row_col()
+            image_group = plate[well_rc[0]][well_rc[1]][well_sub_group]
+            tables = roi_tables[well_acquisition.name].keys()
+            for table_name in tables:
+                write_table(
+                    image_group=image_group,
+                    table_name=table_name,
+                    table=roi_tables[well_acquisition.name][table_name],
+                    overwrite=True,
+                    table_type="roi_table",
+                    table_attrs=None,
+                )
+
+            # Create the metadata dictionary: needs a list of all the images
+            well_id = f"{well_rc[0]}{well_rc[1]}"
+            zarr_url = (
+                f"{zarr_dir}/{full_plate_name}/{well_rc[0]}/"
+                f"{well_rc[1]}/{well_sub_group}"
+            )
+            image_list_updates.append(
+                {
+                    "zarr_url": zarr_url,
+                    "attributes": {
+                        "plate": full_plate_name,
+                        "well": well_id,
+                        "acquisition": acquisition.acquisition_id,
+                    },
+                    "types": {"is_3D": is_3D},
+                }
             )
 
-        # Create the metadata dictionary: needs a list of all the images
-        well_id = f"{well_rc[0]}{well_rc[1]}"
-        zarr_url = (
-            f"{zarr_dir}/{full_plate_name}/{well_rc[0]}/"
-            f"{well_rc[1]}/{well_sub_group}"
-        )
-        image_list_updates.append(
-            {
-                "zarr_url": zarr_url,
-                "attributes": {
-                    "plate": full_plate_name,
-                    "well": well_id,
-                },
-                "types": {"is_3D": is_3D},
-            }
-        )
-
     return {"image_list_updates": image_list_updates}
+
+
+def add_acquisition_metadata_to_wells(plate_url, acquisition_id):
+    """
+    Add acquisition metadata to all the wells in the plate.
+
+    Args:
+        plate_url: Plate url of the OME-Zarr plate.
+        acquisition_id: Acquisition ID to add to the wells.
+    """
+    ngio_plate = ngio.open_ome_zarr_plate(plate_url, cache=True, parallel_safe=False)
+    wells = ngio_plate.wells_paths()
+    for well in wells:
+        row, col = well.split("/")
+        ngio_well = ngio_plate.get_well(row=row, column=col)
+        if str(acquisition_id) in ngio_well.paths():
+            # To add acquisition metadata, remove the image & add it fresh
+            # Only modifies plate metadata, not the image data
+            ngio_plate.remove_image(row=row, column=col, image_path=str(acquisition_id))
+            ngio_plate.add_image(
+                row=row,
+                column=col,
+                image_path=str(acquisition_id),
+                acquisition_id=acquisition_id,
+                acquisition_name=str(acquisition_id),
+            )
+
+
+def check_is_multiplexing(acquisitions: list[AcquisitionInputModel]):
+    """
+    Check that the acquisitions are valid & whether it's multiplexing.
+
+    The acquisitions .plate_name should either be unique (=> non-multiplexing)
+    or they should be all the same, but the acquisition_ids should be unique
+    (=> multiplexing). If the acquisitions are not valid, raise an error.
+
+    Args:
+        acquisitions: List of acquisition directories to convert to OME-Zarr.
+            If you are processing multiplexing experiments, name the plate the
+            same for all acquisitions, but give them unique acquisition IDs.
+            If you are processing multiple separate plates, give the plates
+            unique names.
+    """
+    plate_names = [acquisition.plate_name for acquisition in acquisitions]
+    acquisition_ids = [acquisition.acquisition_id for acquisition in acquisitions]
+
+    if len(plate_names) == 0:
+        raise ValueError("No plate acquisitions provided. Please check your input.")
+
+    if len(plate_names) == 1:
+        return False
+    if len(set(plate_names)) == 1:
+        # All the same plate name
+        if len(set(acquisition_ids)) == len(acquisition_ids):
+            # All the acquisition IDs are unique
+            return True
+        else:
+            raise ValueError(
+                "Acquisition IDs should be unique for multiplexing "
+                "experiments. Please check your input.",
+            )
+    else:
+        # All the plate names are different
+        return False
 
 
 if __name__ == "__main__":

--- a/src/fractal_faim_ipa/convert_ome_zarr.py
+++ b/src/fractal_faim_ipa/convert_ome_zarr.py
@@ -9,7 +9,7 @@ from faim_ipa.hcs.acquisition import TileAlignmentOptions
 from faim_ipa.hcs.converter import ConvertToNGFFPlate, NGFFPlate, PlateLayout
 from faim_ipa.stitching import stitching_utils
 from fractal_tasks_core.tables import write_table
-from pydantic import validate_call
+from pydantic import BaseModel, Field, validate_call
 
 from fractal_faim_ipa.md_converter_utils import ModeEnum
 from fractal_faim_ipa.roi_tables import create_ROI_tables
@@ -17,11 +17,33 @@ from fractal_faim_ipa.roi_tables import create_ROI_tables
 logger = logging.getLogger(__name__)
 
 
+class AcquisitionInputModel(BaseModel):
+    """Acquisition metadata.
+
+    Based on
+    https://github.com/fractal-analytics-platform/fractal-hcs-converters
+
+    Attributes:
+        path: Path to the acquisition directory. For the MD, this is the folder
+            that contains a date folder and an ID folder. If the images are in
+            /path/to/project_name/2025-05-12/1234, then the path should be
+            /path/to/project_name.
+        plate_name: Optional custom name for the plate. If not provided, the name will
+            be the acquisition directory name.
+        acquisition_id: Acquisition ID,
+            used to identify the acquisition in case of multiple acquisitions.
+    """
+
+    path: str
+    plate_name: str | None = None
+    acquisition_id: int = Field(default=0, ge=0)
+
+
 @validate_call
 def convert_ome_zarr(
     *,
     zarr_dir: str,
-    image_dir: str,
+    acquisitions: list[AcquisitionInputModel],
     # # TODO: Figure out a way to use the Enums directly with working manifest building
     # mode: ModeEnum = "MD Stack Acquisition",
     # layout: PlateLayout = 96,
@@ -31,7 +53,6 @@ def convert_ome_zarr(
         "Single Plane Acquisition",
         "Mixed Acquisition",
     ],
-    zarr_name: str = "Plate",
     tile_alignment: Literal["StageAlignment", "GridAlignment"] = "GridAlignment",
     layout: Literal[96, 384] = 96,
     num_levels: int = 5,
@@ -51,7 +72,11 @@ def convert_ome_zarr(
         zarr_dir: path of the directory where the new OME-Zarrs will be
             created.
             (standard argument for Fractal tasks, managed by Fractal server).
-        image_dir: Path to the folder containing the images to be converted.
+        acquisitions: List of acquisition directories to convert to OME-Zarr. If
+            you are processing multiplexing experiments, name the plate the
+            same for all acquisitions, but give them unique acquisition IDs.
+            If you are processing multiple separate plates, give the plates
+            unique names.
         zarr_name: Name of the zarr plate file that will be created
         mode: Choose conversion mode. Choose whether you have 3D data
             (StackAcquisition), 2D data (Single Plane Acquisition) or mixed
@@ -80,16 +105,20 @@ def convert_ome_zarr(
     tile_alignment = TileAlignmentOptions(tile_alignment)
     zarr_dir = zarr_dir.rstrip("/")
 
+    # TODO: Loop over plates for multiplexing or creating multiple plates
+    plate_name = acquisitions[0].plate_name
+    if plate_name is None:
+        plate_name = acquisitions[0].path.rstrip("/").split("/")[-1]
     # TO REVIEW: Overwrite checks are not exposed in faim-hcs API
     # Unclear how faim-hcs handles rerunning the plate creation
     # (the Zarr file gets a newer timestamp at least)
     # This block triggers a reset
-    if overwrite and exists(join(zarr_dir, zarr_name + ".zarr")):
+    if overwrite and exists(join(zarr_dir, plate_name + ".zarr")):
         # Remove zarr if it already exists.
-        shutil.rmtree(join(zarr_dir, zarr_name + ".zarr"))
+        shutil.rmtree(join(zarr_dir, plate_name + ".zarr"))
 
     plate_acquisition = mode.get_plate_acquisition(
-        acquisition_dir=image_dir,
+        acquisition_dir=acquisitions[0].path,
         alignment=tile_alignment,
     )
 
@@ -107,7 +136,7 @@ def convert_ome_zarr(
     converter = ConvertToNGFFPlate(
         ngff_plate=NGFFPlate(
             root_dir=zarr_dir,
-            name=zarr_name,
+            name=plate_name,
             layout=int(layout),
             order_name=order_name,
             barcode=barcode,
@@ -124,7 +153,7 @@ def convert_ome_zarr(
     well_sub_group = "0"
     well_acquisitions = plate_acquisition.get_well_acquisitions(selection=None)
 
-    plate_name = zarr_name + ".zarr"
+    full_plate_name = plate_name + ".zarr"
 
     image_list_updates = []
     # TODO: Add more robust handling for dimensionality detection
@@ -161,12 +190,15 @@ def convert_ome_zarr(
 
         # Create the metadata dictionary: needs a list of all the images
         well_id = f"{well_rc[0]}{well_rc[1]}"
-        zarr_url = f"{zarr_dir}/{plate_name}/{well_rc[0]}/{well_rc[1]}/{well_sub_group}"
+        zarr_url = (
+            f"{zarr_dir}/{full_plate_name}/{well_rc[0]}/"
+            f"{well_rc[1]}/{well_sub_group}"
+        )
         image_list_updates.append(
             {
                 "zarr_url": zarr_url,
                 "attributes": {
-                    "plate": plate_name,
+                    "plate": full_plate_name,
                     "well": well_id,
                 },
                 "types": {"is_3D": is_3D},

--- a/src/fractal_faim_ipa/dev/task_list.py
+++ b/src/fractal_faim_ipa/dev/task_list.py
@@ -3,6 +3,9 @@
 from fractal_task_tools.task_models import ConverterNonParallelTask
 
 DOCS_LINK = "https://github.com/fractal-analytics-platform/fractal-faim-ipa"
+INPUT_MODELS = [
+    ["fractal_faim_ipa", "convert_ome_zarr.py", "AcquisitionInputModel"],
+]
 TASK_LIST = [
     ConverterNonParallelTask(
         name="FAIM IPA OME-Zarr Converter",

--- a/tests/test_converter_task.py
+++ b/tests/test_converter_task.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import anndata as ad
 import pytest
 import zarr
-
 from fractal_faim_ipa.convert_ome_zarr import convert_ome_zarr
 
 
@@ -30,7 +29,14 @@ def count_arrays_in_group(group_url: str) -> int:
 
 def test_ome_zarr_conversion(tmp_path):
     ROOT_DIR = Path(__file__).parent
-    image_dir = str(join(ROOT_DIR.parent, "resources", "Projection-Mix"))
+    output_name = "OME-Zarr"
+    acquisitions = [
+        {
+            "path": str(join(ROOT_DIR.parent, "resources", "Projection-Mix")),
+            "plate_name": output_name,
+            "acquisition_id": 0,
+        }
+    ]
     zarr_root = Path(tmp_path, "zarr-files")
     zarr_root.mkdir()
 
@@ -40,12 +46,9 @@ def test_ome_zarr_conversion(tmp_path):
     barcode = "example-barcode"
     overwrite = True
 
-    output_name = "OME-Zarr"
-
     image_list_update = convert_ome_zarr(
         zarr_dir=str(zarr_root),
-        image_dir=image_dir,
-        zarr_name=output_name,
+        acquisitions=acquisitions,
         mode=mode,
         layout=96,
         order_name=order_name,
@@ -153,7 +156,14 @@ def test_ome_zarr_conversion(tmp_path):
 @pytest.mark.parametrize("num_levels", [2, 5, 8])
 def test_md_converter_pyramid_levels(tmp_path, num_levels):
     ROOT_DIR = Path(__file__).parent
-    image_dir = str(join(ROOT_DIR.parent, "resources", "Projection-Mix"))
+    output_name = "OME-Zarr"
+    acquisitions = [
+        {
+            "path": str(join(ROOT_DIR.parent, "resources", "Projection-Mix")),
+            "plate_name": output_name,
+            "acquisition_id": 0,
+        }
+    ]
     zarr_root = Path(tmp_path, "zarr-files")
     zarr_root.mkdir()
 
@@ -163,12 +173,9 @@ def test_md_converter_pyramid_levels(tmp_path, num_levels):
     barcode = "example-barcode"
     overwrite = True
 
-    output_name = "OME-Zarr"
-
     image_list_update = convert_ome_zarr(
         zarr_dir=str(zarr_root),
-        image_dir=image_dir,
-        zarr_name=output_name,
+        acquisitions=acquisitions,
         mode=mode,
         layout=96,
         num_levels=num_levels,
@@ -179,3 +186,39 @@ def test_md_converter_pyramid_levels(tmp_path, num_levels):
 
     zarr_url = image_list_update[0]["zarr_url"]
     assert count_arrays_in_group(zarr_url) == num_levels
+
+
+def test_ome_zarr_conversion_multiplex(tmp_path):
+    ROOT_DIR = Path(__file__).parent
+    output_name = "OME-Zarr"
+    acquisitions = [
+        {
+            "path": str(join(ROOT_DIR.parent, "resources", "Projection-Mix")),
+            "plate_name": output_name,
+            "acquisition_id": 0,
+        },
+        {
+            "path": str(join(ROOT_DIR.parent, "resources", "Projection-Mix")),
+            "plate_name": output_name,
+            "acquisition_id": 1,
+        },
+    ]
+    zarr_root = Path(tmp_path, "zarr-files")
+    zarr_root.mkdir()
+
+    mode = "Stack Acquisition"
+
+    order_name = "example-order"
+    barcode = "example-barcode"
+    overwrite = True
+
+    convert_ome_zarr(
+        zarr_dir=str(zarr_root),
+        acquisitions=acquisitions,
+        mode=mode,
+        layout=96,
+        order_name=order_name,
+        barcode=barcode,
+        overwrite=overwrite,
+    )["image_list_updates"]
+    print(zarr_root)

--- a/tests/test_converter_task.py
+++ b/tests/test_converter_task.py
@@ -27,14 +27,13 @@ def count_arrays_in_group(group_url: str) -> int:
     return array_count
 
 
-def test_ome_zarr_conversion(tmp_path):
+def test_ome_zarr_conversion_simple(tmp_path):
     ROOT_DIR = Path(__file__).parent
     output_name = "OME-Zarr"
     acquisitions = [
         {
             "path": str(join(ROOT_DIR.parent, "resources", "Projection-Mix")),
             "plate_name": output_name,
-            "acquisition_id": 0,
         }
     ]
     zarr_root = Path(tmp_path, "zarr-files")
@@ -44,7 +43,7 @@ def test_ome_zarr_conversion(tmp_path):
 
     order_name = "example-order"
     barcode = "example-barcode"
-    overwrite = True
+    reset_plates = True
 
     image_list_update = convert_ome_zarr(
         zarr_dir=str(zarr_root),
@@ -53,19 +52,28 @@ def test_ome_zarr_conversion(tmp_path):
         layout=96,
         order_name=order_name,
         barcode=barcode,
-        overwrite=overwrite,
+        reset_plates=reset_plates,
     )["image_list_updates"]
+    print(image_list_update)
     expected_image_list_update = [
         {
             "zarr_url": f"{zarr_root}/{output_name}.zarr/E/07/0",
-            "attributes": {"plate": output_name + ".zarr", "well": "E07"},
+            "attributes": {
+                "plate": output_name + ".zarr",
+                "well": "E07",
+                "acquisition": 0,
+            },
             "types": {
                 "is_3D": True,
             },
         },
         {
             "zarr_url": f"{zarr_root}/{output_name}.zarr/E/08/0",
-            "attributes": {"plate": output_name + ".zarr", "well": "E08"},
+            "attributes": {
+                "plate": output_name + ".zarr",
+                "well": "E08",
+                "acquisition": 0,
+            },
             "types": {
                 "is_3D": True,
             },
@@ -171,7 +179,7 @@ def test_md_converter_pyramid_levels(tmp_path, num_levels):
 
     order_name = "example-order"
     barcode = "example-barcode"
-    overwrite = True
+    reset_plates = True
 
     image_list_update = convert_ome_zarr(
         zarr_dir=str(zarr_root),
@@ -181,7 +189,7 @@ def test_md_converter_pyramid_levels(tmp_path, num_levels):
         num_levels=num_levels,
         order_name=order_name,
         barcode=barcode,
-        overwrite=overwrite,
+        reset_plates=reset_plates,
     )["image_list_updates"]
 
     zarr_url = image_list_update[0]["zarr_url"]
@@ -210,15 +218,126 @@ def test_ome_zarr_conversion_multiplex(tmp_path):
 
     order_name = "example-order"
     barcode = "example-barcode"
-    overwrite = True
+    reset_plates = True
 
-    convert_ome_zarr(
+    image_list_update = convert_ome_zarr(
         zarr_dir=str(zarr_root),
         acquisitions=acquisitions,
         mode=mode,
         layout=96,
         order_name=order_name,
         barcode=barcode,
-        overwrite=overwrite,
+        reset_plates=reset_plates,
     )["image_list_updates"]
-    print(zarr_root)
+    expected_image_list_update = [
+        {
+            "zarr_url": f"{zarr_root}/{output_name}.zarr/E/08/0",
+            "attributes": {
+                "plate": output_name + ".zarr",
+                "well": "E08",
+                "acquisition": 0,
+            },
+            "types": {
+                "is_3D": True,
+            },
+        },
+        {
+            "zarr_url": f"{zarr_root}/{output_name}.zarr/E/07/0",
+            "attributes": {
+                "plate": output_name + ".zarr",
+                "well": "E07",
+                "acquisition": 0,
+            },
+            "types": {
+                "is_3D": True,
+            },
+        },
+        {
+            "zarr_url": f"{zarr_root}/{output_name}.zarr/E/08/1",
+            "attributes": {
+                "plate": output_name + ".zarr",
+                "well": "E08",
+                "acquisition": 1,
+            },
+            "types": {
+                "is_3D": True,
+            },
+        },
+        {
+            "zarr_url": f"{zarr_root}/{output_name}.zarr/E/07/1",
+            "attributes": {
+                "plate": output_name + ".zarr",
+                "well": "E07",
+                "acquisition": 1,
+            },
+            "types": {
+                "is_3D": True,
+            },
+        },
+    ]
+    assert expected_image_list_update == image_list_update
+
+
+def test_ome_zarr_conversion_multi_plate(tmp_path):
+    ROOT_DIR = Path(__file__).parent
+    acquisitions = [
+        {
+            "path": str(join(ROOT_DIR.parent, "resources", "Projection-Mix")),
+            "plate_name": "plate_1",
+            "acquisition_id": 0,
+        },
+        {
+            "path": str(join(ROOT_DIR.parent, "resources", "Projection-Mix")),
+            "plate_name": "plate_2",
+            "acquisition_id": 0,
+        },
+    ]
+    zarr_root = Path(tmp_path, "zarr-files")
+    zarr_root.mkdir()
+
+    mode = "Stack Acquisition"
+
+    order_name = "example-order"
+    barcode = "example-barcode"
+    reset_plates = True
+
+    image_list_update = convert_ome_zarr(
+        zarr_dir=str(zarr_root),
+        acquisitions=acquisitions,
+        mode=mode,
+        layout=96,
+        order_name=order_name,
+        barcode=barcode,
+        reset_plates=reset_plates,
+    )["image_list_updates"]
+    expected_image_list_update = [
+        {
+            "zarr_url": f"{zarr_root}/plate_1.zarr/E/08/0",
+            "attributes": {"plate": "plate_1.zarr", "well": "E08", "acquisition": 0},
+            "types": {
+                "is_3D": True,
+            },
+        },
+        {
+            "zarr_url": f"{zarr_root}/plate_1.zarr/E/07/0",
+            "attributes": {"plate": "plate_1.zarr", "well": "E07", "acquisition": 0},
+            "types": {
+                "is_3D": True,
+            },
+        },
+        {
+            "zarr_url": f"{zarr_root}/plate_2.zarr/E/08/0",
+            "attributes": {"plate": "plate_2.zarr", "well": "E08", "acquisition": 0},
+            "types": {
+                "is_3D": True,
+            },
+        },
+        {
+            "zarr_url": f"{zarr_root}/plate_2.zarr/E/07/0",
+            "attributes": {"plate": "plate_2.zarr", "well": "E07", "acquisition": 0},
+            "types": {
+                "is_3D": True,
+            },
+        },
+    ]
+    assert expected_image_list_update == image_list_update

--- a/tests/test_metaxpress_md_conversion.py
+++ b/tests/test_metaxpress_md_conversion.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import dask.array as da
 import pytest
-
 from fractal_faim_ipa.convert_ome_zarr import convert_ome_zarr
 
 ROOT_DIR = Path(__file__).parent
@@ -22,10 +21,18 @@ def test_montage(tmp_path, tile_alignment, expected_shape):
     mode = "Stack Acquisition"
     zarr_root = Path(tmp_path, "zarr-files")
     zarr_root.mkdir()
+
+    acquisitions = [
+        {
+            "path": image_dir,
+            "plate_name": output_name,
+            "acquisition_id": 0,
+        }
+    ]
+
     convert_ome_zarr(
         zarr_dir=str(zarr_root),
-        image_dir=image_dir,
-        zarr_name=output_name,
+        acquisitions=acquisitions,
         mode=mode,
         tile_alignment=tile_alignment,
         order_name=order_name,

--- a/tests/test_metaxpress_md_conversion.py
+++ b/tests/test_metaxpress_md_conversion.py
@@ -9,7 +9,7 @@ ROOT_DIR = Path(__file__).parent
 image_dir = str(join(ROOT_DIR.parent, "resources", "zmb-test-data_Plate_0000"))
 order_name = "example-order"
 barcode = "example-barcode"
-overwrite = True
+reset_plates = True
 output_name = "Test_ZMB_3D"
 
 
@@ -37,7 +37,7 @@ def test_montage(tmp_path, tile_alignment, expected_shape):
         tile_alignment=tile_alignment,
         order_name=order_name,
         barcode=barcode,
-        overwrite=overwrite,
+        reset_plates=reset_plates,
     )
     print(zarr_root)
     print(f"{zarr_root!s}/{output_name}.zarr/C/03/0/0")


### PR DESCRIPTION
This PR add multiplexing support to the MD converter by running the converter for each multiplexing plate and adding the acquisition metadata separately afterwards.

It also adds support for processing multiple MD plates at once.