### PR TITLE
Improve errors for invalid input paths

### DIFF
--- a/src/fractal_faim_ipa/convert_cellvoyager_to_ome_zarr.py
+++ b/src/fractal_faim_ipa/convert_cellvoyager_to_ome_zarr.py
@@ -112,6 +112,17 @@ def convert_cellvoyager_to_ome_zarr(  # noqa: C901
         plate_name = acquisition.plate_name
         if plate_name is None:
             plate_name = acquisition.path.rstrip("/").split("/")[-1]
+
+        # Check if folder exists. faim-ipa errors when wrong paths are
+        # entered are often confusing to users. Fail early if an input path
+        # doesn't even exist / isn't accessible.
+        if not exists(acquisition.path):
+            raise FileNotFoundError(
+                f"Acquisition path {acquisition.path} does not exist or "
+                "is not accessible. Make sure you specify the path in a "
+                "manner that is accessible from where the task is run."
+            )
+
         if exists(join(zarr_dir, plate_name + ".zarr")):
             if reset_plates:
                 # Remove zarr if it already exists.

--- a/src/fractal_faim_ipa/convert_md_to_ome_zarr.py
+++ b/src/fractal_faim_ipa/convert_md_to_ome_zarr.py
@@ -107,6 +107,17 @@ def convert_md_to_ome_zarr(  # noqa: C901
         plate_name = acquisition.plate_name
         if plate_name is None:
             plate_name = acquisition.path.rstrip("/").split("/")[-1]
+
+        # Check if folder exists. faim-ipa errors when wrong paths are
+        # entered are often confusing to users. Fail early if an input path
+        # doesn't even exist / isn't accessible.
+        if not exists(acquisition.path):
+            raise FileNotFoundError(
+                f"Acquisition path {acquisition.path} does not exist or "
+                "is not accessible. Make sure you specify the path in a "
+                "manner that is accessible from where the task is run."
+            )
+
         if exists(join(zarr_dir, plate_name + ".zarr")):
             if reset_plates:
                 # Remove zarr if it already exists.

--- a/tests/test_md_converter_task.py
+++ b/tests/test_md_converter_task.py
@@ -393,3 +393,32 @@ def test_ome_zarr_conversion_multi_plate(tmp_path):
         },
     ]
     assert expected_image_list_update == image_list_update
+
+
+def test_ome_zarr_conversion_failure_non_existing_path(tmp_path):
+    output_name = "OME-Zarr"
+    acquisitions = [
+        {
+            "path": "/path/that/does/not/exist",
+            "plate_name": output_name,
+        }
+    ]
+    zarr_root = Path(tmp_path, "zarr-files")
+    zarr_root.mkdir()
+
+    mode = "Stack Acquisition"
+
+    order_name = "example-order"
+    barcode = "example-barcode"
+    reset_plates = True
+
+    with pytest.raises(FileNotFoundError):
+        convert_md_to_ome_zarr(
+            zarr_dir=str(zarr_root),
+            acquisitions=acquisitions,
+            mode=mode,
+            layout=96,
+            order_name=order_name,
+            barcode=barcode,
+            reset_plates=reset_plates,
+        )


### PR DESCRIPTION
Add a check on whether the input path exists to avoid raising confusing faim-ipa processing errors when the acquisition paths are set wrong